### PR TITLE
Bugfix for deleting fields in the backend.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ mpForm wbCMS Content Module
 MODULE VERSION HISTORY 
 ======================
 
+		*** 1.3.1.1 (Dietrich Roland Pehlke: 14-Nov-2016) ***
+		- Bugfix for deleting fields in backend
+		- Set version up to 1.3.1.1 
    ------------------------------------------------------------------------------------------------------------------------ 
         *** 1.3.1 (Martin Hecht: 20-Oct-2016) ***
         add export for results table

--- a/ajax/ajax.php
+++ b/ajax/ajax.php
@@ -30,22 +30,55 @@ $aJsonRespond['success'] = FALSE;
         exit(json_encode($aJsonRespond));
     }
 
+	/**
+	 *	A simple mini-validator function
+	 */
+	function mpFormTestPost( $aFields, &$respose ) {
+		foreach ($aFields as $key=>$options) {
+			if( !isset($_POST[ $key ]) ) {
+				$respose['message'] = "key not submitted";
+				return false;
+			}
+			
+			switch( $options['type'] ) {
+				case 'not_0':
+					if( $_POST[ $key ] === 0 ) return false;
+					break;
+				
+				case 'int':
+					if(!is_numeric($_POST[ $key ])) return false;
+					break;
+		
+				case 'str':
+					if(!is_string( $_POST[ $key ]))  return false;
+					if(isset($options['values'])) {
+						if(!in_array( $_POST[ $key ], $options['values'] )) return false;
+					}
+					break;
+			
+				default:
+					// no "type" match
+					return false;
+			}
+		}
+		return true;
+	}
 
+	/**
+	 *	A list for the $_POST values/keys we want to test.
+	 */
+	$fields = array(
+		'iRecordID' 		=> array( 'type' => 'not_0' ),
+		'iSectionID' 		=> array( 'type' => 'int' ),
+		'purpose'			=> array( 'type' => 'str' ),
+		'DB_RECORD_TABLE'	=> array( 'type' => 'str' , 'values' => array( 'mpform_fields' , 'mpform_submissions' ) ),
+		'DB_COLUMN'			=> array( 'type' => 'str' , 'values' => array( 'field_id', 'submission_id' ) ),
+		'MODULE'			=> array( 'type' => 'str' , 'values' => array( 'mpform' ) )
+	);
+	
 
-    // check if arguments are set
-    if (    
-        isset($_POST['iRecordID']) && $_POST['iRecordID'] !=0
-        && isset($_POST['iSectionID']) && is_numeric($_POST['iSectionID'])
-        && isset($_POST['purpose']) && is_string($_POST['purpose'])
-        && isset($_POST['DB_RECORD_TABLE']) && is_string($_POST['DB_RECORD_TABLE'])
-        && (  ($_POST['DB_RECORD_TABLE'] == 'mpform_fields') 
-           || ($_POST['DB_RECORD_TABLE'] == 'mpform_submissions'))
-        && isset($_POST['DB_COLUMN']) && is_string($_POST['DB_COLUMN'])
-        && (  ($_POST['DB_COLUMN'] == 'field_id') 
-           || ($_POST['DB_COLUMN'] == 'submission_id'))
-        && isset($_POST['MODULE']) && is_string($_POST['MODULE'])
-        && (  ($_POST['MODULE'] == 'mpform'))
-    )
+	// check if arguments are set
+	if ( true === mpFormTestPost( $fields, $aJsonRespond ) )
     {
         // require config for Core Constants
         require('../../../config.php');
@@ -71,7 +104,7 @@ $aJsonRespond['success'] = FALSE;
             exit(json_encode($aJsonRespond));
         }
         
-    } else    {
+    } else {
         $aJsonRespond['message'] = 'Post arguments missing';
         $aJsonRespond['success'] = FALSE;
         exit(json_encode($aJsonRespond));

--- a/info.php
+++ b/info.php
@@ -22,7 +22,7 @@
 $module_directory   = 'mpform';
 $module_name        = 'mpForm';
 $module_function    = 'page';
-$module_version     = '1.3.1';
+$module_version     = '1.3.1.1';
 $module_platform    = '2.8.x';
 $module_status      = 'stable';
 $module_author      = 'Frank Heyne, NorHei(heimsath.org), Christian M. Stefan (Stefek), Martin Hecht (mrbaseman) and others';


### PR DESCRIPTION
Add a simple minivalidator for the „massiv“ AND/OR conditions inside
ajax.php for testing the submitted values.